### PR TITLE
dont remove chiral H, and update implicit H count when removed

### DIFF
--- a/src/main/java/gov/nih/ncats/molwitch/Chemical.java
+++ b/src/main/java/gov/nih/ncats/molwitch/Chemical.java
@@ -688,12 +688,12 @@ public class Chemical {
 	 * @return true (currently always even if nothing is removed)
 	 */
 	public boolean removeNonDescriptHydrogens() {
-
-		Stream<Atom> atomsToCheck = atoms();
-		if (this.hasSGroups()) {
+		Chemical t=this;
+		Stream<Atom> atomsToCheck = t.atoms();
+		if (t.hasSGroups()) {
 
 			Stream<Atom> atomsToIgnore = Stream.empty();
-			for(SGroup sgroup : this.getSGroups()){
+			for(SGroup sgroup : t.getSGroups()){
 				atomsToIgnore = Stream.concat(atomsToIgnore, sgroup.getAtoms());
 				atomsToIgnore = Stream.concat(atomsToIgnore,  sgroup.getOutsideNeighbors());
 			}
@@ -704,8 +704,12 @@ public class Chemical {
 
 		for (Atom ca : atomsToCheck.filter(a-> a.getSymbol().equals("H"))
 				.filter(h -> h.getMassNumber() ==0 && h.getRadical() == 0
-						&& h.getChirality().getParity() == 0 && h.getCharge() == 0
-						&& !h.getAtomToAtomMap().isPresent())
+						&& h.getBondCount()==1 
+						&& h.getCharge() == 0
+						&& !h.getAtomToAtomMap().isPresent()
+						&& h.getNeighbors().get(0).getChirality().getParity() == 0
+						)
+				.filter(h -> !"H".equals(h.getNeighbors().get(0).getSymbol()))
 				.collect(Collectors.toList())
 
 		) {
@@ -713,8 +717,19 @@ public class Chemical {
 			for (Bond cb : ca.getBonds()) {
 				Atom ca2 = cb.getOtherAtom(ca);
 				if (!ca2.isQueryAtom()) {
-					if (cb.getStereo() == Bond.Stereo.NONE) {
-						this.removeAtom(ca);
+					Integer hcount = ca2.getImplicitHCount();
+					if(hcount==null){
+						hcount=0;	
+					}
+					//This gets weird if there is no stereo bond
+					//concept in the underlying toolkit
+					if (cb.getStereo() == Bond.Stereo.NONE) { 
+						t.removeAtom(ca);
+						// It's not ideal to do this, but is required by some
+						// libraries. We may consider making the act of
+						// removing a Hydrogen through removeAtom
+						// due this already if neeeded.
+						ca2.setImplicitHCount(hcount+1);
 					}
 				}
 			}


### PR DESCRIPTION
As it says above, this makes it so that "non-descript" hydrogens DON'T include H-H hyrdrogens and H's with a chiral bond on a 0-dimensional structure. Also, updated implict H count explicitly when removed.