### PR TITLE
Jna inchi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>gov.nih.ncats</groupId>
             <artifactId>ncats-common</artifactId>
-            <version>0.3.6-SNAPSHOT</version>
+            <version>0.3.6</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.github.dan2097</groupId>
+            <artifactId>jna-inchi-all</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
             <groupId>uk.ac.cam.ch.opsin</groupId>
             <artifactId>opsin-core</artifactId>
-            <version>2.3.1</version>
+            <version>3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/gov/nih/ncats/molwitch/inchi/Inchi.java
+++ b/src/main/java/gov/nih/ncats/molwitch/inchi/Inchi.java
@@ -26,8 +26,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import gov.nih.ncats.common.util.CachedSupplier;
+import gov.nih.ncats.molwitch.Atom;
 import gov.nih.ncats.molwitch.Chemical;
 import gov.nih.ncats.molwitch.spi.InchiImplFactory;
+import io.github.dan2097.jnainchi.*;
 
 public final class Inchi {
 
@@ -39,14 +41,57 @@ public final class Inchi {
 		return list;
 	});
 	private static Pattern STD_INCHI_PREFIX = Pattern.compile("^\\s*InChI=1S/");
-	
+
 	public static InChiResult asStdInchi(Chemical chemical) throws IOException{
-		return asStdInchi(chemical, false);
+		return asStdInchi(chemical, true);
+	}
+	private static InChiResult.Status convertEnumStatus(InchiStatus status){
+		if(status == InchiStatus.SUCCESS ){
+			return InChiResult.Status.VALID;
+		}
+		if(status == InchiStatus.WARNING){
+			return InChiResult.Status.WARNING;
+		}
+		return InChiResult.Status.ERROR;
+
+	}
+	private static boolean canDoDirectInchi(Chemical orig){
+		boolean hasProblemAtoms = orig.atoms()
+				.filter(a -> a.isQueryAtom() || a.isRGroupAtom() || a.isPseudoAtom())
+				.findAny()
+				.isPresent();
+		return !hasProblemAtoms;
 	}
 	public static InChiResult asStdInchi(Chemical chemical, boolean trustCoordinates) throws IOException{
+		if(canDoDirectInchi(chemical)) {
+			String molText = chemical.toMol();
+			InchiOutput output = JnaInchi.molToInchi(molText);
+			InChiResult.Builder builder = new InChiResult.Builder(convertEnumStatus(output.getStatus()));
+			builder.setMessage(output.getMessage() == null ? "" : output.getMessage());
+			builder.setAuxInfo(output.getAuxInfo() == null ? "" : output.getAuxInfo());
+
+
+			if (output.getStatus() == InchiStatus.SUCCESS || output.getStatus() == InchiStatus.WARNING) {
+				String fullInchi = output.getInchi();
+				builder.setInchi(fullInchi);
+				InchiKeyOutput keyOutput = JnaInchi.inchiToInchiKey(fullInchi);
+				if (keyOutput.getStatus() == InchiKeyStatus.OK) {
+					builder.setKey(keyOutput.getInchiKey());
+				}else{
+					builder.setKey("");
+				}
+				return builder.build();
+			}
+
+		}
+		//if we can't get the inchi for some reason fall back and ask the molwitch implementation to do it
+		return computeInchiFromFactory(chemical, trustCoordinates);
+	}
+
+	private static InChiResult computeInchiFromFactory(Chemical chemical, boolean trustCoordinates) throws IOException{
 		for(InchiImplFactory impl : implLoaders.get()) {
 			InChiResult result =  impl.asStdInchi(chemical, trustCoordinates);
-			
+
 			if(result !=null) {
 				return result;
 			}


### PR DESCRIPTION
This switches the inchi implementation from the old jni-inchi to jna-inchi this also bumps the inchi spec from 1.03 to 1.06